### PR TITLE
Add server retrieval endpoints and commands

### DIFF
--- a/OK workspaces/hecate.py
+++ b/OK workspaces/hecate.py
@@ -219,6 +219,12 @@ class Hecate:
         elif user_input.strip() == "clone:memories":
             return self._clone_memories()
 
+        elif user_input.strip() == "clone:tasks":
+            return self._clone_list_tasks()
+
+        elif user_input.strip() == "clone:results":
+            return self._clone_results()
+
         elif user_input.strip() == "lattice:show":
             return self.lattice.list_tasks()
 
@@ -641,6 +647,28 @@ class Hecate:
         with open(self.shared_memory_file, "r") as f:
             data = f.read().strip()
         return data if data else f"{self.name}: (no memories)"
+
+    def _clone_list_tasks(self):
+        if self.clone_server:
+            try:
+                resp = requests.get(f"{self.clone_server}/tasks", timeout=5)
+                if resp.ok:
+                    tasks = resp.json().get("tasks", [])
+                    return "\n".join(tasks) if tasks else f"{self.name}: (no tasks)"
+            except Exception:
+                pass
+        return f"{self.name}: Task listing not available."
+
+    def _clone_results(self):
+        if self.clone_server:
+            try:
+                resp = requests.get(f"{self.clone_server}/results", timeout=5)
+                if resp.ok:
+                    data = resp.text.strip()
+                    return data if data else f"{self.name}: (no results)"
+            except Exception:
+                pass
+        return f"{self.name}: No results found."
 
     def _load_admin_status(self):
         try:

--- a/README.md
+++ b/README.md
@@ -33,6 +33,13 @@ To sync clones over a network, start `clone_network.py` on one machine and set t
 python clone_client.py --help
 ```
 
+The client now includes commands to list queued tasks and retrieve stored results:
+
+```bash
+python clone_client.py list-tasks    # view tasks without consuming them
+python clone_client.py results       # print task results reported by clones
+```
+
 ### Sensitive Data Firewall
 `clone_network.py` now masks API keys and other tokens from shared messages and tasks. Set `FIREWALL_PATTERNS` with comma-separated regexes to customize what gets filtered.
 

--- a/clone_client.py
+++ b/clone_client.py
@@ -56,6 +56,24 @@ def submit_result(result: str):
         print('error:', resp.text)
 
 
+def get_results():
+    resp = requests.get(f"{SERVER_URL}/results")
+    if resp.ok:
+        print(resp.text)
+    else:
+        print('error:', resp.text)
+
+
+def list_tasks():
+    resp = requests.get(f"{SERVER_URL}/tasks")
+    if resp.ok:
+        data = resp.json()
+        for t in data.get('tasks', []):
+            print(t)
+    else:
+        print('error:', resp.text)
+
+
 def main():
     parser = argparse.ArgumentParser(description='Interact with a clone server')
     sub = parser.add_subparsers(dest='cmd')
@@ -71,9 +89,12 @@ def main():
     sub.add_parser('memories', help='read shared facts')
 
     sub.add_parser('fetch-task', help='request a queued task')
+    sub.add_parser('list-tasks', help='list queued tasks without consuming them')
 
     result_p = sub.add_parser('submit-result', help='report task result')
     result_p.add_argument('result')
+
+    sub.add_parser('results', help='retrieve stored task results')
 
     args = parser.parse_args()
 
@@ -87,8 +108,12 @@ def main():
         get_memories()
     elif args.cmd == 'fetch-task':
         fetch_task()
+    elif args.cmd == 'list-tasks':
+        list_tasks()
     elif args.cmd == 'submit-result':
         submit_result(args.result)
+    elif args.cmd == 'results':
+        get_results()
     else:
         parser.print_help()
 

--- a/clone_network.py
+++ b/clone_network.py
@@ -138,6 +138,18 @@ def store_result():
         return jsonify({'status': 'stored'})
     return jsonify({'error': 'missing result'}), 400
 
+# New endpoint to fetch stored results
+@app.route('/results', methods=['GET'])
+def get_results():
+    """Return results reported by clones."""
+    return '\n'.join(results)
+
+# New endpoint to list queued tasks without removing them
+@app.route('/tasks', methods=['GET'])
+def list_tasks():
+    """Return the current task queue."""
+    return jsonify({'tasks': list(tasks)})
+
 if __name__ == '__main__':
     port = int(os.getenv('CLONE_PORT', '5000'))
     app.run(host='0.0.0.0', port=port)


### PR DESCRIPTION
## Summary
- extend clone network with `/results` and `/tasks` endpoints
- update command-line client with `list-tasks` and `results` commands
- expose new clone commands in Hecate to fetch tasks and results
- document the new client commands in README

## Testing
- `git ls-files '*.py' -z | xargs -0 python -m py_compile`
- `python clone_client.py --help | head`


------
https://chatgpt.com/codex/tasks/task_e_68887366cc68832f9a9a43d59d60c083